### PR TITLE
approval_token needs to be bytes object (as in test case)

### DIFF
--- a/transferwise/client/client.py
+++ b/transferwise/client/client.py
@@ -44,10 +44,7 @@ class Client:
     def _get_approval_signature(self, approval_token: str):
         signature = self._private_key.sign(
             approval_token,
-            padding.PSS(
-                mgf=padding.MGF1(hashes.SHA256()),
-                salt_length=padding.PSS.MAX_LENGTH
-            ),
+            padding.PKCS1v15(),
             hashes.SHA256()
         )
         return base64.b64encode(signature).decode()

--- a/transferwise/client/client.py
+++ b/transferwise/client/client.py
@@ -60,7 +60,7 @@ class Client:
                 if not try_again:
                     self.logger.warning(response.json())
                     return response.json()
-                approval_token = response.headers.get('x-2fa-approval')
+                approval_token = response.headers.get('x-2fa-approval').encode('UTF-8')
                 approval_headers = self.get_approval_headers(approval_token)
                 return self._request(url, method, approval_headers, params, payload, try_again=False)
             if not response.ok:


### PR DESCRIPTION
approval_token as string created TypeError
the PSS padding used previously was rejected by wise